### PR TITLE
PowerMax Driver - Fix for snapVx generations - part 2

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/powermax/powermax_data.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/powermax/powermax_data.py
@@ -889,7 +889,7 @@ class PowerMaxData(object):
     # replication
     volume_snap_vx = {'snapshotLnks': [],
                       'snapshotSrcs': [
-                          {'generation': '0',
+                          {'generation': 0,
                            'linkedDevices': [
                                {'targetDevice': device_id2,
                                 'percentageCopied': 100,
@@ -899,6 +899,49 @@ class PowerMaxData(object):
                                 'linked': True}],
                            'snapshotName': test_snapshot_snap_name,
                            'state': 'Established'}]}
+
+    volume_snap_vx_gen_0_str = (
+        {'snapshotLnks': [],
+         'snapshotSrcs': [
+             {'generation': '0',
+              'linkedDevices': [
+                  {'targetDevice': device_id2,
+                   'percentageCopied': 100,
+                   'state': 'Copied',
+                   'copy': True,
+                   'defined': True,
+                   'linked': True}],
+              'snapshotName': test_snapshot_snap_name,
+              'state': 'Established'}]})
+
+    volume_snap_vx_gen_1 = (
+        {'snapshotLnks': [],
+         'snapshotSrcs': [
+             {'generation': 1,
+              'linkedDevices': [
+                  {'targetDevice': device_id2,
+                   'percentageCopied': 100,
+                   'state': 'Copied',
+                   'copy': True,
+                   'defined': True,
+                   'linked': True}],
+              'snapshotName': test_snapshot_snap_name,
+              'state': 'Established'}]})
+
+    volume_snap_vx_gen_1_str = (
+        {'snapshotLnks': [],
+         'snapshotSrcs': [
+             {'generation': '1',
+              'linkedDevices': [
+                  {'targetDevice': device_id2,
+                   'percentageCopied': 100,
+                   'state': 'Copied',
+                   'copy': True,
+                   'defined': True,
+                   'linked': True}],
+              'snapshotName': test_snapshot_snap_name,
+              'state': 'Established'}]})
+
     capabilities = {'symmetrixCapability': [{'rdfCapable': True,
                                              'snapVxCapable': True,
                                              'symmetrixId': '0001111111'},

--- a/cinder/tests/unit/volume/drivers/dell_emc/powermax/test_powermax_rest.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/powermax/test_powermax_rest.py
@@ -1342,6 +1342,59 @@ class PowerMaxRestTest(test.TestCase):
             snap = self.rest.get_volume_snap(array, device_id, snap_name)
             self.assertIsNone(snap)
 
+    def test_get_volume_snap_gen_0(self):
+        array = self.data.array
+        snap_name = self.data.volume_snap_vx['snapshotSrcs'][0]['snapshotName']
+        device_id = self.data.device_id
+        ref_snap = self.data.volume_snap_vx['snapshotSrcs'][0]
+        snap = self.rest.get_volume_snap(array, device_id, snap_name, 0)
+        self.assertEqual(ref_snap, snap)
+        snap = self.rest.get_volume_snap(array, device_id, snap_name, '0')
+        self.assertEqual(ref_snap, snap)
+
+    def test_get_volume_snap_gen_1(self):
+        array = self.data.array
+        snap_name = (
+            self.data.volume_snap_vx_gen_1['snapshotSrcs'][0]['snapshotName'])
+        device_id = self.data.device_id
+        ref_snap = self.data.volume_snap_vx_gen_1['snapshotSrcs'][0]
+        with mock.patch.object(self.rest, 'get_volume_snap_info',
+                               return_value=self.data.volume_snap_vx_gen_1):
+            snap = self.rest.get_volume_snap(array, device_id, snap_name, 1)
+            self.assertEqual(ref_snap, snap)
+            snap = self.rest.get_volume_snap(array, device_id, snap_name, '1')
+            self.assertEqual(ref_snap, snap)
+
+    def test_get_volume_snap_gen_str_0(self):
+        array = self.data.array
+        snap_name = (
+            self.data.volume_snap_vx_gen_0_str[
+                'snapshotSrcs'][0]['snapshotName'])
+        device_id = self.data.device_id
+        ref_snap = self.data.volume_snap_vx_gen_0_str['snapshotSrcs'][0]
+        with mock.patch.object(
+                self.rest, 'get_volume_snap_info',
+                return_value=self.data.volume_snap_vx_gen_0_str):
+            snap = self.rest.get_volume_snap(array, device_id, snap_name, 0)
+            self.assertEqual(ref_snap, snap)
+            snap = self.rest.get_volume_snap(array, device_id, snap_name, '0')
+            self.assertEqual(ref_snap, snap)
+
+    def test_get_volume_snap_gen_str_1(self):
+        array = self.data.array
+        snap_name = (
+            self.data.volume_snap_vx_gen_1_str[
+                'snapshotSrcs'][0]['snapshotName'])
+        device_id = self.data.device_id
+        ref_snap = self.data.volume_snap_vx_gen_1_str['snapshotSrcs'][0]
+        with mock.patch.object(
+                self.rest, 'get_volume_snap_info',
+                return_value=self.data.volume_snap_vx_gen_1_str):
+            snap = self.rest.get_volume_snap(array, device_id, snap_name, 1)
+            self.assertEqual(ref_snap, snap)
+            snap = self.rest.get_volume_snap(array, device_id, snap_name, '1')
+            self.assertEqual(ref_snap, snap)
+
     def test_get_snap_linked_device_dict_list(self):
         array = self.data.array
         snap_name = 'temp-snapshot'
@@ -1399,7 +1452,8 @@ class PowerMaxRestTest(test.TestCase):
     def test_find_snap_vx_sessions_tgt_only(self, mck_snap, mck_vol):
         array = self.data.array
         source_id = self.data.device_id
-        ref_session = {'generation': '6', 'state': 'Linked', 'copy_mode': False,
+        ref_session = {'generation': '6', 'state': 'Linked',
+                       'copy_mode': False,
                        'snap_name': 'temp-000AA-snapshot_for_clone',
                        'source_vol_id': self.data.device_id2,
                        'target_vol_id': source_id, 'expired': True}

--- a/cinder/volume/drivers/dell_emc/powermax/utils.py
+++ b/cinder/volume/drivers/dell_emc/powermax/utils.py
@@ -1993,3 +1993,20 @@ class PowerMaxUtils(object):
         :returns: str
         """
         return in_value if isinstance(in_value, str) else str(in_value)
+
+    def verify_snap_using_gen(self, snap_vx, gen):
+        """Check if snap has the correct generation number
+
+        This also allows for the generation to be brought
+        back as an int without Python treating 0 as a False
+
+        :param snap_vx: the snapVX object
+        :param gen: the generation number
+        :returns: snap_vx or None
+        """
+        snap_gen = snap_vx.get('generation')
+        snap_gen = self.convert_to_string(snap_gen)
+        if snap_gen and snap_gen.isdigit():
+            if int(snap_gen) == int(gen):
+                return snap_vx
+        return None


### PR DESCRIPTION
Need to tighten the code to except a generation as an int or
a string in both request and response bodies.