### PR TITLE
PowerMax Driver - Fix for snapVx generations - part 3

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/powermax/test_powermax_common.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/powermax/test_powermax_common.py
@@ -2392,9 +2392,12 @@ class PowerMaxCommonTest(test.TestCase):
                           self.common.manage_existing_snapshot,
                           snapshot, existing_ref)
 
+    @mock.patch.object(common.PowerMaxCommon, '_get_gen_with_uuid',
+                       return_value=(None, None))
     @mock.patch.object(rest.PowerMaxRest, 'get_volume_snap',
                        return_value=False)
-    def test_manage_snapshot_fail_vol_not_snap_src(self, mock_snap):
+    def test_manage_snapshot_fail_vol_not_snap_src(
+            self, mock_snap, mock_uuid):
         snapshot = self.data.test_snapshot_manage
         existing_ref = {u'source-name': u'test_snap'}
         self.assertRaises(exception.VolumeBackendAPIException,
@@ -2402,8 +2405,10 @@ class PowerMaxCommonTest(test.TestCase):
                           snapshot, existing_ref)
 
     @mock.patch.object(utils.PowerMaxUtils, 'modify_snapshot_prefix',
-                       side_effect=exception.VolumeBackendAPIException)
-    def test_manage_snapshot_fail_add_prefix(self, mock_mod):
+                       return_value=None)
+    @mock.patch.object(rest.PowerMaxRest, 'get_volume_snap',
+                       return_value=tpd.PowerMaxData.priv_snap_response)
+    def test_manage_snapshot_fail_add_prefix(self, mock_snap, mock_mod):
         snapshot = self.data.test_snapshot_manage
         existing_ref = {u'source-name': u'test_snap'}
         self.assertRaises(exception.VolumeBackendAPIException,

--- a/cinder/tests/unit/volume/drivers/dell_emc/powermax/test_powermax_rest.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/powermax/test_powermax_rest.py
@@ -1235,7 +1235,8 @@ class PowerMaxRestTest(test.TestCase):
         payload_restore = {'deviceNameListSource': [{'name': source_id}],
                            'deviceNameListTarget': [{'name': source_id}],
                            'action': 'Restore',
-                           'star': 'false', 'force': 'false'}
+                           'star': 'false', 'force': 'false',
+                           'generation': '0'}
         with mock.patch.object(
                 self.rest, 'modify_resource',
                 return_value=(202, self.data.job_list[0])) as mock_modify:

--- a/cinder/volume/drivers/dell_emc/powermax/common.py
+++ b/cinder/volume/drivers/dell_emc/powermax/common.py
@@ -2903,8 +2903,20 @@ class PowerMaxCommon(object):
         rep_model_update, rep_driver_data = dict(), dict()
         rep_extra_specs = dict()
         extra_specs = self._initial_setup(volume)
-        array, device_id = self.utils.get_array_and_device_id(
-            volume, external_ref)
+        try:
+            array, device_id = self.utils.get_array_and_device_id(
+                volume, external_ref)
+        except exception.VolumeBackendAPIException:
+            array, device_id = self._manage_volume_with_uuid(
+                external_ref, volume)
+
+        if not device_id:
+            exception_message = _(
+                "Unable to get the device id to manage volume into OpenStack.")
+            LOG.error(exception_message)
+            raise exception.VolumeBackendAPIException(
+                message=exception_message)
+
         volume_id = volume.id
 
         # Check if the existing volume is valid for cinder management
@@ -2985,6 +2997,31 @@ class PowerMaxCommon(object):
             volume, rep_info_dict, device_id, extra_specs)
 
         return model_update
+
+    def _manage_volume_with_uuid(self, external_ref, volume):
+        """Manage volume using the uuid
+
+        :param external_ref: the external reference
+        :param volume: the volume object
+        :raises: VolumeBackendAPIException
+        :returns: array, device_id -- str, str
+        """
+        LOG.debug("External_ref: %(er)s", {'er': external_ref})
+        uuid_vol = external_ref.get('source-name', None)
+        if not uuid_vol:
+            uuid_vol = external_ref.get('source-id', None)
+        if uuid_vol:
+            uuid_vol = uuid_vol.replace('OS-', '').replace('volume-', '')
+        if uuid_vol and self.utils.check_uuid_regex(uuid_vol):
+            array = self.utils.get_array_from_host(volume)
+            device_id = self.rest.find_volume_device_id(array, uuid_vol)
+            return array, device_id
+        else:
+            exception_message = _(
+                "Unable to verify the uuid of volume.")
+            LOG.error(exception_message)
+            raise exception.VolumeBackendAPIException(
+                message=exception_message)
 
     def _protect_storage_group(
             self, array, device_id, volume, volume_name, rep_extra_specs):
@@ -3114,8 +3151,20 @@ class PowerMaxCommon(object):
         """
         LOG.debug("Volume in manage_existing_get_size: %(volume)s.",
                   {'volume': volume})
-        array, device_id = self.utils.get_array_and_device_id(
-            volume, external_ref)
+        try:
+            array, device_id = self.utils.get_array_and_device_id(
+                volume, external_ref)
+        except exception.VolumeBackendAPIException:
+            array, device_id = self._manage_volume_with_uuid(
+                external_ref, volume)
+
+        if not device_id:
+            exception_message = _(
+                "Unable to get the device id to manage volume into OpenStack.")
+            LOG.error(exception_message)
+            raise exception.VolumeBackendAPIException(
+                message=exception_message)
+
         # Ensure the volume exists on the array
         volume_details = self.rest.get_volume(array, device_id)
         if not volume_details:
@@ -3198,10 +3247,18 @@ class PowerMaxCommon(object):
         :raises: VolumeBackendAPIException
         :returns: model update
         """
+        persist_metadata = True
         volume = snapshot.volume
         extra_specs = self._initial_setup(volume)
         array = extra_specs[utils.ARRAY]
         device_id = self._find_device_on_array(volume, extra_specs)
+        if not device_id:
+            exception_message = (
+                (_("Cannot find device for volume %(name)s.") % {
+                    'name': volume.id}))
+            LOG.error(exception_message)
+            raise exception.VolumeBackendAPIException(
+                message=exception_message)
 
         try:
             snap_name = existing_ref['source-name']
@@ -3231,20 +3288,27 @@ class PowerMaxCommon(object):
                 message=exception_message)
 
         if not self.rest.get_volume_snap(array, device_id, snap_name):
-            exception_message = (
-                _("Snapshot %(snap_name)s is not associated with specified "
-                  "volume %(device_id)s, it is not possible to manage a "
-                  "snapshot that is not associated with the specified "
-                  "volume.")
-                % {'device_id': device_id, 'snap_name': snap_name})
-            LOG.error(exception_message)
-            raise exception.VolumeBackendAPIException(
-                message=exception_message)
+            __, new_snap_name = self._get_gen_with_uuid(
+                array, device_id, snap_name)
+            if new_snap_name is None:
+                exception_message = (
+                        _("Snapshot %(snap_name)s is not associated with specified "
+                          "volume %(device_id)s, it is not possible to manage a "
+                          "snapshot that is not associated with the specified "
+                          "volume.")
+                        % {'device_id': device_id, 'snap_name': snap_name})
+                LOG.error(exception_message)
+                raise exception.VolumeBackendAPIException(
+                    message=exception_message)
+            snap_name = new_snap_name
+            persist_metadata = False
 
         snap_backend_name = self.utils.modify_snapshot_prefix(
             snap_name, manage=True)
 
         try:
+            if snap_backend_name is None:
+                raise
             self.rest.modify_volume_snap(
                 array, device_id, device_id, snap_name,
                 extra_specs, rename=True, new_snap_name=snap_backend_name)
@@ -3262,9 +3326,11 @@ class PowerMaxCommon(object):
         model_update = {
             'display_name': snap_display_name,
             'provider_location': six.text_type(prov_loc)}
-        model_update = self.update_metadata(
-            model_update, snapshot.metadata, self.get_snapshot_metadata(
-                array, device_id, snap_backend_name))
+        snapshot_metadata = self.get_snapshot_metadata(
+            array, device_id, snap_backend_name)
+        if persist_metadata:
+            model_update = self.update_metadata(
+                model_update, snapshot.metadata, snapshot_metadata)
 
         LOG.info("Managing SnapVX Snapshot %(snap_name)s of source "
                  "volume %(device_id)s, OpenStack Snapshot display name: "
@@ -3273,6 +3339,25 @@ class PowerMaxCommon(object):
                      'snap_display_name': snap_display_name})
 
         return model_update
+
+    def _get_gen_with_uuid(self, array, device_id, snap_name):
+        """Get the generation using the uuid as input
+
+        :param array: the serial number of the array
+        :param device_id: the device id of the volume
+        :param snap_name: the snap_name containing the uuid
+        :returns: snap_id, snap_name -- str, str
+        """
+        gen = None
+        snap_uuid = snap_name.replace('_snapshot-', '')
+        element_name = self.utils.get_volume_element_name(snap_uuid)
+        snap_name = self.utils.truncate_string(element_name, 19)
+        snap_name = snap_name.replace('OS-', '')
+        snap_list = self.rest.get_volume_snaps(
+            array, device_id, snap_name)
+        if len(snap_list) == 1:
+            gen = snap_list[0].get('generation')
+        return gen, snap_name
 
     def manage_existing_snapshot_get_size(self, snapshot):
         """Return the size of the source volume for manage-existing-snapshot.

--- a/cinder/volume/drivers/dell_emc/powermax/rest.py
+++ b/cinder/volume/drivers/dell_emc/powermax/rest.py
@@ -2033,7 +2033,7 @@ class PowerMaxRest(object):
     def modify_volume_snap(self, array, source_id, target_id, snap_name,
                            extra_specs, link=False, unlink=False,
                            rename=False, new_snap_name=None, restore=False,
-                           list_volume_pairs=None, generation="0", copy=False):
+                           list_volume_pairs=None, generation='0', copy=False):
         """Modify a snapvx snapshot
 
         :param array: the array serial number
@@ -2069,7 +2069,8 @@ class PowerMaxRest(object):
             payload = {"deviceNameListSource": [{"name": source_id}],
                        "deviceNameListTarget": [{"name": source_id}],
                        "action": action,
-                       "star": 'false', "force": 'false'}
+                       "star": 'false', "force": 'false',
+                       "generation": generation}
         elif action in ('Link', 'Unlink'):
             operation = 'Modify snapVx relationship to target'
             src_list, tgt_list = [], []
@@ -2091,7 +2092,8 @@ class PowerMaxRest(object):
             operation = 'Rename snapVx snapshot'
             payload = {"deviceNameListSource": [{"name": source_id}],
                        "deviceNameListTarget": [{"name": source_id}],
-                       "action": action, "newsnapshotname": new_snap_name}
+                       "action": action, "newsnapshotname": new_snap_name,
+                       "generation": generation}
 
         if action:
             status_code, job = self.modify_resource(
@@ -2137,7 +2139,7 @@ class PowerMaxRest(object):
         return self.get_resource(array, REPLICATION, 'volume',
                                  resource_name, private='/private')
 
-    def get_volume_snap(self, array, device_id, snap_name, generation="0"):
+    def get_volume_snap(self, array, device_id, snap_name, generation='0'):
         """Given a volume snap info, retrieve the snapVx object.
 
         :param array: the array serial number
@@ -2157,6 +2159,24 @@ class PowerMaxRest(object):
                         if snapshot:
                             return snapshot
         return None
+
+    def get_volume_snaps(self, array, device_id, snap_name):
+        """Given a volume snap info, retrieve the snapVx object.
+
+        :param array: the array serial number
+        :param device_id: the source volume device id
+        :param snap_name: the name of the snapshot
+        :returns: snapshot dict, or None
+        """
+        snapshots = list()
+        snap_info = self.get_volume_snap_info(array, device_id)
+        if snap_info:
+            if (snap_info.get('snapshotSrcs', None) and
+                    bool(snap_info['snapshotSrcs'])):
+                for snap in snap_info['snapshotSrcs']:
+                    if snap['snapshotName'] == snap_name:
+                        snapshots.append(snap)
+        return snapshots
 
     def get_volume_snapshot_list(self, array, source_device_id):
         """Get a list of snapshot details for a particular volume.

--- a/cinder/volume/drivers/dell_emc/powermax/utils.py
+++ b/cinder/volume/drivers/dell_emc/powermax/utils.py
@@ -2010,3 +2010,15 @@ class PowerMaxUtils(object):
             if int(snap_gen) == int(gen):
                 return snap_vx
         return None
+
+    @staticmethod
+    def check_uuid_regex(volume_id):
+        """Check the uuid regex
+
+        :param volume_id: the unique volume identifier
+        :returns: bool
+        """
+        uuid_regex = (re.compile(
+            r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}',
+            re.I))
+        return uuid_regex.search(volume_id)


### PR DESCRIPTION
Generation must be supplied in both restore and rename
snapshot operations
Also must supply the following specifically for tempest
testing
https://review.opendev.org/c/openstack/cinder/+/772388